### PR TITLE
Feature/mc 9533

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,7 @@
 dependencies {
     implementation group: 'uk.ac.ox.softeng.maurodatamapper', name: 'mdm-core', version: mdmCoreVersion
     implementation group: 'uk.ac.ox.softeng.maurodatamapper', name: 'mdm-plugin-datamodel', version: mdmCoreVersion
+    implementation group: 'uk.ac.ox.softeng.maurodatamapper', name: 'mdm-plugin-profile', version: mdmCoreVersion
 
     if(findProject(':mdm-plugin-database')) implementation project(':mdm-plugin-database')
     else implementation group: 'uk.ac.ox.softeng.maurodatamapper.plugins', name: 'mdm-plugin-database', version: mdmPluginDatabaseVersion

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ shadowGradlePluginVersion=2.0.1
 ciRun=false
 # Mauro Data Mapper
 mdmCoreVersion=4.11.0
-mdmPluginDatabaseVersion=5.1.0
+mdmPluginDatabaseVersion=5.2.0-SNAPSHOT
 mdmPluginTestUtilsVersion=5.0.0
 # Other
 groovyVersion=2.5.14

--- a/src/conf/db.migration/migrate_metadata_namespaces.sql
+++ b/src/conf/db.migration/migrate_metadata_namespaces.sql
@@ -1,0 +1,26 @@
+--Metadata for the dialect is migrated to the .sqlserver namespace
+UPDATE core.metadata
+SET namespace = 'uk.ac.ox.softeng.maurodatamapper.plugins.database.sqlserver'
+WHERE namespace = 'uk.ac.ox.softeng.maurodatamapper.plugins.database'
+AND multi_facet_aware_item_domain_type = 'DataModel'
+AND key = 'dialect'
+AND value = 'MS SQL Server';
+
+--Metadata on DataElement is migrated to the .sqlserver.column namespace
+UPDATE core.metadata
+SET namespace = 'uk.ac.ox.softeng.maurodatamapper.plugins.database.sqlserver.column'
+WHERE namespace = 'uk.ac.ox.softeng.maurodatamapper.plugins.database.sqlserver'
+AND multi_facet_aware_item_domain_type = 'DataElement';
+
+--Metadata on DataClass where the DataClass is a table rather than a schema is migrated to the .sqlserver.table namespace
+UPDATE core.metadata
+SET namespace = 'uk.ac.ox.softeng.maurodatamapper.plugins.database.sqlserver.table'
+WHERE namespace = 'uk.ac.ox.softeng.maurodatamapper.plugins.database.sqlserver'
+AND multi_facet_aware_item_domain_type = 'DataClass'
+AND multi_facet_aware_item_id IN (
+    SELECT id FROM datamodel.data_class
+	WHERE parent_data_class_id IS NOT NULL
+);
+
+--No migration to .sqlserver.schema because there isn't a profile for schema
+

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/sqlserver/SqlServerDatabaseDataModelImporterProviderService.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/sqlserver/SqlServerDatabaseDataModelImporterProviderService.groovy
@@ -61,6 +61,26 @@ class SqlServerDatabaseDataModelImporterProviderService
     }
 
     @Override
+    String namespaceColumn() {
+        "uk.ac.ox.softeng.maurodatamapper.plugins.database.sqlserver.column"
+    }
+
+    @Override
+    String namespaceTable() {
+        "uk.ac.ox.softeng.maurodatamapper.plugins.database.sqlserver.table"
+    }
+
+    @Override
+    String namespaceSchema() {
+        "uk.ac.ox.softeng.maurodatamapper.plugins.database.sqlserver.schema"
+    }
+
+    @Override
+    String namespaceDatabase() {
+        "uk.ac.ox.softeng.maurodatamapper.plugins.database.sqlserver"
+    }
+
+    @Override
     DefaultDataTypeProvider getDefaultDataTypeProvider() {
         sqlServerDataTypeProvider
     }
@@ -309,7 +329,7 @@ class SqlServerDatabaseDataModelImporterProviderService
         schemaMetadata.each {Map<String, Object> row ->
             dataModel.childDataClasses.find{dc ->
                 dc.label == row.schema_name
-            }.addToMetadata(namespace, row.metadata_key as String, row.metadata_value as String, dataModel.createdBy)
+            }?.addToMetadata(namespace, row.metadata_key as String, row.metadata_value as String, dataModel.createdBy)
         }
 
         dataModel.childDataClasses.each { DataClass schemaClass ->

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/sqlserver/SqlServerDatabasePlugin.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/sqlserver/SqlServerDatabasePlugin.groovy
@@ -17,6 +17,8 @@
  */
 package uk.ac.ox.softeng.maurodatamapper.plugins.database.sqlserver
 
+import uk.ac.ox.softeng.maurodatamapper.plugins.database.sqlserver.table.SqlServerTableProfileProviderService
+import uk.ac.ox.softeng.maurodatamapper.plugins.database.sqlserver.column.SqlServerColumnProfileProviderService
 import uk.ac.ox.softeng.maurodatamapper.provider.plugin.AbstractMauroDataMapperPlugin
 
 class SqlServerDatabasePlugin extends AbstractMauroDataMapperPlugin {
@@ -31,6 +33,9 @@ class SqlServerDatabasePlugin extends AbstractMauroDataMapperPlugin {
         {->
             sqlServerDatabaseDataModelImporterProviderService SqlServerDatabaseDataModelImporterProviderService
             sqlServerDataTypeProvider SqlServerDataTypeProvider
+            sqlServerDatabaseProfileProviderService SqlServerDatabaseProfileProviderService
+            sqlServerTableProfileProviderService SqlServerTableProfileProviderService
+            sqlServerColumnProfileProviderService SqlServerColumnProfileProviderService
         }
     }
 }

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/sqlserver/SqlServerDatabaseProfileProviderService.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/sqlserver/SqlServerDatabaseProfileProviderService.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020-2021 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package uk.ac.ox.softeng.maurodatamapper.plugins.database.sqlserver
+
+import uk.ac.ox.softeng.maurodatamapper.profile.provider.JsonProfileProviderService
+
+class SqlServerDatabaseProfileProviderService extends JsonProfileProviderService {
+    @Override
+    String getMetadataNamespace() {
+        namespace
+    }
+
+    @Override
+    String getVersion() {
+        getClass().getPackage().getSpecificationVersion() ?: 'SNAPSHOT'
+    }
+
+    @Override
+    String getDisplayName() {
+        'MS SQL Database'
+    }
+
+    @Override
+    String getJsonResourceFile() {
+        'SqlServerDatabaseProfile.json'
+    }
+
+    @Override
+    List<String> profileApplicableForDomains() {
+        return ['DataModel']
+    }
+}

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/sqlserver/column/SqlServerColumnProfileProviderService.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/sqlserver/column/SqlServerColumnProfileProviderService.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020-2021 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package uk.ac.ox.softeng.maurodatamapper.plugins.database.sqlserver.column
+
+import uk.ac.ox.softeng.maurodatamapper.profile.provider.JsonProfileProviderService
+
+class SqlServerColumnProfileProviderService extends JsonProfileProviderService {
+    @Override
+    String getMetadataNamespace() {
+        namespace
+    }
+
+    @Override
+    String getVersion() {
+        getClass().getPackage().getSpecificationVersion() ?: 'SNAPSHOT'
+    }
+
+    @Override
+    String getDisplayName() {
+        'MS SQL Column'
+    }
+
+    @Override
+    String getJsonResourceFile() {
+        'SqlServerColumnProfile.json'
+    }
+
+    @Override
+    List<String> profileApplicableForDomains() {
+        return ['DataElement']
+    }
+}

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/sqlserver/table/SqlServerTableProfileProviderService.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/sqlserver/table/SqlServerTableProfileProviderService.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020-2021 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package uk.ac.ox.softeng.maurodatamapper.plugins.database.sqlserver.table
+
+import uk.ac.ox.softeng.maurodatamapper.profile.provider.JsonProfileProviderService
+
+class SqlServerTableProfileProviderService  extends JsonProfileProviderService {
+    @Override
+    String getMetadataNamespace() {
+        namespace
+    }
+
+    @Override
+    String getVersion() {
+        getClass().getPackage().getSpecificationVersion() ?: 'SNAPSHOT'
+    }
+
+    @Override
+    String getDisplayName() {
+        'MS SQL Table or View'
+    }
+
+    @Override
+    String getJsonResourceFile() {
+        'SqlServerTableProfile.json'
+    }
+
+    @Override
+    List<String> profileApplicableForDomains() {
+        return ['DataClass']
+    }
+}

--- a/src/main/resources/SqlServerColumnProfile.json
+++ b/src/main/resources/SqlServerColumnProfile.json
@@ -1,0 +1,183 @@
+[
+  {
+    "sectionName": "Column Properties",
+    "fields": [
+      {
+        "fieldName": "Foreign Key Name",
+        "metadataPropertyName": "foreign_key_name",
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "string",
+        "derived": false
+      },
+      {
+        "fieldName": "Foreign Key Columns",
+        "metadataPropertyName": "foreign_key_columns",
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "string",
+        "derived": false
+      },
+      {
+        "fieldName": "Primary Key",
+        "metadataPropertyName": "primary key",
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "string",
+        "derived": false
+      },
+      {
+        "fieldName": "Unique",
+        "metadataPropertyName": "unique",
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "string",
+        "derived": false
+      },
+      {
+        "fieldName": "Character Maximum Length",
+        "metadataPropertyName": "character_maximum_length",
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "int",
+        "derived": false
+      },
+      {
+        "fieldName": "Character Octet Length",
+        "metadataPropertyName": "character_octet_length",
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "int",
+        "derived": false
+      },
+      {
+        "fieldName": "Character Set Catalog",
+        "metadataPropertyName": "character_set_catalog",
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "string",
+        "derived": false
+      },
+      {
+        "fieldName": "Character Set Name",
+        "metadataPropertyName": "character_set_name",
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "string",
+        "derived": false
+      },
+      {
+        "fieldName": "Character Set Schema",
+        "metadataPropertyName": "character_set_schema",
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "string",
+        "derived": false
+      },
+      {
+        "fieldName": "Collation Catalog",
+        "metadataPropertyName": "collation_catalog",
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "string",
+        "derived": false
+      },
+      {
+        "fieldName": "Collation Name",
+        "metadataPropertyName": "collation_name",
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "string",
+        "derived": false
+      },
+      {
+        "fieldName": "Collation Schema",
+        "metadataPropertyName": "collation_schema",
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "string",
+        "derived": false
+      },
+      {
+        "fieldName": "Column Default",
+        "metadataPropertyName": "column_default",
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "string",
+        "derived": false
+      },
+      {
+        "fieldName": "Datetime Precision",
+        "metadataPropertyName": "datetime_precision",
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "string",
+        "derived": false
+      },
+      {
+        "fieldName": "Domain Catalog",
+        "metadataPropertyName": "domain_catalog",
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "string",
+        "derived": false
+      },
+      {
+        "fieldName": "Domain Name",
+        "metadataPropertyName": "domain_name",
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "string",
+        "derived": false
+      },
+      {
+        "fieldName": "Domain Schema",
+        "metadataPropertyName": "domain_schema",
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "string",
+        "derived": false
+      },
+      {
+        "fieldName": "Is Nullable",
+        "metadataPropertyName": "is_nullable",
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "string",
+        "derived": false
+      },
+      {
+        "fieldName": "Numeric Precision",
+        "metadataPropertyName": "numeric_precision",
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "int",
+        "derived": false
+      },
+      {
+        "fieldName": "Numeric Precision Radix",
+        "metadataPropertyName": "numeric_precision_radix",
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "int",
+        "derived": false
+      },
+      {
+        "fieldName": "Numeric Scale",
+        "metadataPropertyName": "numeric_scale",
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "int",
+        "derived": false
+      },
+      {
+        "fieldName": "Ordinal Position",
+        "metadataPropertyName": "ordinal_position",
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "int",
+        "derived": false
+      }
+    ]
+  }
+]

--- a/src/main/resources/SqlServerDatabaseProfile.json
+++ b/src/main/resources/SqlServerDatabaseProfile.json
@@ -1,0 +1,15 @@
+[
+  {
+    "sectionName": "Database Properties",
+    "fields": [
+      {
+        "fieldName": "Dialect",
+        "metadataPropertyName": "dialect",
+        "minMultiplicity": 1,
+        "maxMultiplicity": 1,
+        "dataType": "string",
+        "derived": false
+      }
+    ]
+  }
+]

--- a/src/main/resources/SqlServerTableProfile.json
+++ b/src/main/resources/SqlServerTableProfile.json
@@ -1,0 +1,47 @@
+[
+  {
+    "sectionName": "Table / View Properties",
+    "fields": [
+      {
+        "fieldName": "Primary Key name",
+        "metadataPropertyName": "primary_key_name",
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "string",
+        "derived": false
+      },
+      {
+        "fieldName": "Primary Key Columns",
+        "metadataPropertyName": "primary_key_columns",
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "string",
+        "derived": false
+      },
+      {
+        "fieldName": "Unique Constraint Name",
+        "metadataPropertyName": "unique_name",
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "string",
+        "derived": false
+      },
+      {
+        "fieldName": "Unique Constraint Columns",
+        "metadataPropertyName": "unique_columns",
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "string",
+        "derived": false
+      },
+      {
+        "fieldName": "Indexes",
+        "metadataPropertyName": "indexes",
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "string",
+        "derived": false
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Three profile providers are added so that metadata stored against the imported Data Model, Data Class and Data Elements can be retrieved profiled. 

In contrast to the similar PR for the PostgreSQL plugin, there is no profile at the Schema level. This is because the only properties which are stored against the schema are SQL Server Extended Properties; the names of these are not known in advance and so cannot be added to the defined profile structure.

Metadata is stored against new namespaces; separate namespaces are used so that the profile structure can be uniquely identified.

The data migration script, intended for manual use, can be used to update the namespaces of metadata on previously imported data.